### PR TITLE
Loop Mutations

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -518,7 +518,6 @@ def list_comprehension_mutation(children, node, **_):
     # find in, everything asfter that is the list
     children = children[:]
     list_idx = None
-    pdb.set_trace()
     for idx, child in enumerate(children):
         if child.type == 'keyword' and child.value == 'in':
             list_idx = idx + 1

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import copy
 import re
 import sys
-import pdb
 
 from parso import parse
 from parso.python.tree import Name, Number, Keyword, Newline, PythonNode
@@ -407,15 +406,15 @@ def loop_mutation(children, node, **_):
     """
     Mutates loop
 
-    For loop children is structered as the nodes that make up the loop defintion (for x in y:) and a suite
-    The suite is a newline, indented, statement, then dedent and naother newline
+    For loop children is structured as the nodes that make up the loop defintion (for x in y:) and a suite
+    The suite is a newline, indented, statement, then dedent and another newline
     """
     # for x in y
     # node.get_defined_names() = x
     # node.get_testlist() = y
 
     mutations = {}
-    # need to deep copy inside subfuctions, otherwise both mutations applied at same time
+    # need to deep copy inside subfunctions, otherwise both mutations applied at same time
     # but the deep copy breaks that new != old check in mutate_node, will throw the source assert in mutate()
     if node.type == 'for_stmt':
         mutations['zero'] = zero_loop_mutation_for(children, node, **_)
@@ -682,7 +681,6 @@ def mutate_node(node, context):
             # I guess a set might be fine too, best would be a custom data struct
             new_mutations = []
             if type(new_evaluation) == dict:
-                #print("Multiple mutations for %s", node.get_code())
                 new_mutations = new_evaluation.values()
             else:
                 new_mutations.append(new_evaluation)

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -468,17 +468,23 @@ def one_loop_mutation(base_children, node, **_):
             # new break position is at next line, but keep the column indent
             line = last_element.end_pos[0]
             new_pos = (line, indent_col)
-            # need to put the prefix back into the first element
-            # TODO: create helper function to build these nodes
-            prefix = ' ' * indent_col
 
-            kw_node = Keyword(value='break', start_pos=new_pos, prefix=prefix)
-            nl_node = Newline(value='\n', start_pos=kw_node.end_pos)
-            break_node = PythonNode('simple_stmt', [kw_node, nl_node])
+            break_node = create_break_node(new_pos)
 
             suite.children.append(break_node)
             break
     return children
+
+def create_break_node(pos):
+    """ Creates a break node.
+        pos: (line, column)
+    """
+    # prefix needs to be added to the first element
+    prefix = ' ' * pos[1]
+    kw_node = Keyword(value='break', start_pos=pos, prefix=prefix)
+    nl_node = Newline(value='\n', start_pos=kw_node.end_pos)
+    break_node = PythonNode('simple_stmt', [kw_node, nl_node])
+    return break_node
 
 
 mutations_by_type = {

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -513,6 +513,23 @@ def create_break_node(pos):
     break_node = PythonNode('simple_stmt', [kw_node, nl_node])
     return break_node
 
+def list_comprehension_mutation(children, node, **_):
+    # for exprlist in or_test [comp_iter]
+    # find in, everything asfter that is the list
+    children = children[:]
+    list_idx = None
+    pdb.set_trace()
+    for idx, child in enumerate(children):
+        if child.type == 'keyword' and child.value == 'in':
+            list_idx = idx + 1
+            break
+    if not list_idx:
+        return None
+    # assuming the list is of type Name
+    empty_list = Name(value=' []', start_pos=children[list_idx].start_pos)
+    children[list_idx] = empty_list
+    return children[:list_idx+1]
+
 
 mutations_by_type = {
     'operator': dict(value=operator_mutation),
@@ -529,6 +546,7 @@ mutations_by_type = {
     'annassign': dict(children=expression_mutation),
     'for_stmt': dict(children=loop_mutation),
     'while_stmt': dict(children=loop_mutation),
+    'comp_for': dict(children=list_comprehension_mutation),
 }
 
 # TODO: detect regexes and mutate them in nasty ways? Maybe mutate all strings as if they are regexes

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -401,6 +401,33 @@ def name_mutation(node, value, **_):
     if function_call_pattern.matches(node=node):
         return 'None'
 
+def loop_mutation(children, node, **_):
+    """
+    Mutates loop
+
+    Zero-run loop: Replaces iteration list with a blank list []
+        Surviving Test Case: Only write test case that checks for an empty loop
+        
+    """
+    # for x in y
+    # node.get_defined_names() = x
+    # node.get_testlist() = y
+
+    children = children[:]
+    empty_loop = ' []'
+
+    testlist = node.get_testlist()
+
+    for idx, c in enumerate(children):
+        if c is testlist:
+            children[idx] = Name(
+                    value=empty_loop,
+                    start_pos=testlist.start_pos)
+            break
+
+    return children
+    
+
 
 mutations_by_type = {
     'operator': dict(value=operator_mutation),
@@ -415,6 +442,7 @@ mutations_by_type = {
     'expr_stmt': dict(children=expression_mutation),
     'decorator': dict(children=decorator_mutation),
     'annassign': dict(children=expression_mutation),
+    'for_stmt': dict(children=loop_mutation),
 }
 
 # TODO: detect regexes and mutate them in nasty ways? Maybe mutate all strings as if they are regexes


### PR DESCRIPTION
Multiple mutations per operator - return the mutations as a dict <name, mutation> (key name doesn't matter too much right now). The type is check and if it's a dict, split it up and handle those multiples.

Adding loop mutations:
* For loop
  * Run loop body zero times - replace iteration list with empty
  * Run loop body exactly once - add break to end of loop body
* While loop
  * Run loop zero times - add break immediately after while statement
  * Run loop exactly once - add break to the end of loop body

Still in work:
* List comprehension For
  * Mutation done, but unit test still needed