### PR TITLE
Fix try_stmt performance problem

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -689,7 +689,7 @@ def try_block_mutation_helper(children, marker_clause_index, stmt_creator_fn):
     suite_index = locate_next_suite_or_stmt_index(children, marker_clause_index)
     if suite_index >= 0:
         # Replace the block with a mutation; either a pass or a raise.
-        new_children = copy.deepcopy(children)
+        new_children = copy.copy(children)
         pos = new_children[suite_index].start_pos
         mutated_node = stmt_creator_fn(pos)
         new_children[suite_index] = mutated_node


### PR DESCRIPTION
For try_stmt mutations, deep copying children nodes is overkill and causes excessive memory usage and extremely poor performance on real world code.  All that is needed is to shallow copy the top level list of children, then replace the child to be mutated with a synthesized mutated statement.