### PR TITLE
Converting loop mutation deepcopy into a shallow copy.

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -518,9 +518,17 @@ def list_comprehension_mutation(children, node, **_):
     children = children[:]
     list_idx = None
     for idx, child in enumerate(children):
-        if child.type == 'keyword' and child.value == 'in':
-            list_idx = idx + 1
-            break
+        if child.type == 'keyword':
+            if child.value == 'in':
+                list_idx = idx + 1
+                break
+            # A previous mutator may turn the `in` into `not in` in memory
+            # However, the node type will still be correct as it was parsed pre-mutation
+            # This workaround is required since we are not mutating clean code
+            elif child.value == 'not in':
+                list_idx = idx + 1
+                child.value = 'in'
+                break
     if not list_idx:
         return None
     # assuming the list is of type Name

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -365,3 +365,13 @@ __all__ = [
 ]
 """
     assert mutate(Context(source=source)) == (source, 0)
+
+def test_mutate_list_comprehension():
+    source = 'z = [x for x in y]'
+    mutations = list_mutations(Context(source=source))
+    assert len(mutations) == 3
+    # This can't be tested in basic because the unproductive not in mutation interferes with the [] mutation, and with the cache this clobbers the None mutation. This has been worked around by unmutating the not in.
+    assert mutate(Context(source=source, mutation_id=mutations[0])) == ('z = [x for x not in y]', 1)
+    assert mutate(Context(source=source, mutation_id=mutations[1])) == ('z = [x for x in []]', 1)
+    assert mutate(Context(source=source, mutation_id=mutations[2])) == ('z = None', 1)
+

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -188,7 +188,6 @@ def test_basic_mutations_python36(original, expected):
         'import foo',
         'import foo as bar',
         'foo.bar',
-        'for x in y: pass',
         'def foo(a, *args, **kwargs): pass',
         'import foo',
     ]


### PR DESCRIPTION
A single shallow copy doesn't work, because the actual loop children are nested several layers deep inside the node object. What we really want is a shallow copy of the container that holds the suite node's children, and the child nodes themselves should not be copied. 

children -> suite node -> suite node's children

Added helper function to do that copying, updated the one-loop and zero-while mutations to use it (0-for doesn't need it since it operates on the for statement and not the children). Also removed a unit test that did not mutate loops.